### PR TITLE
docs: add Platform-Docs cross-references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,140 +1,23 @@
 # Contributing to Vindicta-CLI
 
-Thank you for contributing to Vindicta-CLI! All contributions **must** follow the [Platform Constitution](https://github.com/vindicta-platform/.specify/blob/main/memory/constitution.md).
+Thank you for your interest in contributing!
 
-## Prerequisites
+## Cross-Cutting Decisions
 
-- **Python 3.10+**
-- **[uv](https://docs.astral.sh/uv/)** — package & virtualenv manager
-- **[pre-commit](https://pre-commit.com/)** — git hook framework
-- **Git** configured with your GitHub account
+> **⚠️ Important:** All decisions that affect multiple repositories or have platform-wide implications **must** be recorded in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs) before implementation.
 
-## Getting Started
+This includes:
+- API contract changes
+- Shared schema modifications
+- Authentication/authorization changes
+- New inter-service dependencies
+- Platform-wide configuration changes
 
-```bash
-# 1. Clone the repository
-git clone https://github.com/vindicta-platform/Vindicta-CLI.git
-cd Vindicta-CLI
+See the [Platform-Docs Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md) for the full process.
 
-# 2. Create a virtual environment and install dev dependencies
-uv venv
-uv pip install -e ".[dev]"
+## Repo-Specific Guidelines
 
-# 3. ⚠️ MANDATORY — Install pre-commit hooks
-pre-commit install
-pre-commit install --hook-type pre-push
-
-# 4. Verify your setup
-pre-commit run --all-files
-pytest tests/ -v
-```
-
-> [!IMPORTANT]
-> **Steps 3 is non-negotiable.** Pre-commit hooks enforce linting (ruff), formatting (ruff-format), trailing whitespace removal, end-of-file fixing, and YAML validation. Skipping this step means your commits will fail CI.
-
-## Pre-Commit Hooks
-
-The `.pre-commit-config.yaml` enforces the following on every commit:
-
-| Hook                  | Purpose                                           |
-| --------------------- | ------------------------------------------------- |
-| `ruff`                | Lint Python code (E, F, I, W rules) with auto-fix |
-| `ruff-format`         | Format Python code (88-char line length)          |
-| `trailing-whitespace` | Remove trailing whitespace                        |
-| `end-of-file-fixer`   | Ensure files end with a newline                   |
-| `check-yaml`          | Validate YAML syntax                              |
-
-To run hooks manually against all files:
-
-```bash
-pre-commit run --all-files
-```
-
-To update hooks to their latest versions:
-
-```bash
-pre-commit autoupdate
-```
-
-## Development Workflow
-
-### 1. Create a Feature Branch
-
-```bash
-git checkout -b feat/<ID>-<short-name>
-# Example: git checkout -b feat/042-credit-ledger
-```
-
-### 2. Follow the SDD Lifecycle
-
-Every feature must go through Spec-Driven Development:
-
-1. **Specify** — Create spec in `specs/<ID>-<name>/spec.md`
-2. **Plan** — Write `plan.md` with architecture and file changes
-3. **Tasks** — Generate dependency-ordered `tasks.md`
-4. **Implement** — Atomic TDD commits (Red → Green → Refactor)
-5. **Verify** — Verification checklist with evidence
-
-### 3. Write Tests First (TDD)
-
-```bash
-# Run the full test suite
-pytest tests/ -v
-
-# Run a specific test file
-pytest tests/unit/test_example.py -v
-
-# Run with coverage
-pytest tests/ -v --cov=src/vindicta_cli
-```
-
-### 4. Commit & Push
-
-```bash
-git add .
-git commit -m "feat(<scope>): <description>"
-# Pre-commit hooks run automatically here
-git push origin feat/<ID>-<short-name>
-```
-
-### 5. Open a Pull Request
-
-- Target: `main`
-- Reference the SDD spec ID in the PR description
-- Include a verification checklist
-- All CI checks must pass before merge
-
-## Quality Gates
-
-| Gate                 | Requirement                                     |
-| -------------------- | ----------------------------------------------- |
-| **Pre-commit hooks** | All hooks pass (ruff, format, whitespace, YAML) |
-| **Unit tests**       | 100% pass, >80% coverage on critical paths      |
-| **CI pipeline**      | GitHub Actions checks green                     |
-| **Code review**      | At least one approval                           |
-
-## Code Style
-
-- **Line length**: 88 characters (configured in `pyproject.toml`)
-- **Linter**: ruff with `E, F, I, W` rule sets
-- **Target**: Python 3.10+
-- **Imports**: Sorted by `isort` (via ruff `I` rules)
-
-## Project Structure
-
-```
-Vindicta-CLI/
-├── src/vindicta_cli/   # Source code
-├── tests/              # Test suite
-│   ├── unit/           # Unit tests
-│   └── integration/    # Integration tests
-├── docs/               # Documentation (mkdocs)
-├── specs/              # SDD specification bundles
-├── .pre-commit-config.yaml
-├── pyproject.toml
-└── CONTRIBUTING.md     # ← You are here
-```
-
-## License
-
-MIT License — See [LICENSE](./LICENSE) for details.
+1. Follow existing code style and conventions
+2. Write tests for new functionality
+3. Keep PRs focused and atomic
+4. Reference related [Platform-Docs proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals) when applicable

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 ![Version 0.2.0](https://img.shields.io/badge/version-0.2.0-orange)
 
 ## Overview
-
 Vindicta-CLI is a [Typer](https://typer.tiangolo.com/)-based CLI that provides developer workspace management for the 26-repo Vindicta Platform. It handles repository cloning, synchronisation, health checks, validation, and configuration — all with [Rich](https://rich.readthedocs.io/) terminal output and optional `--json` machine-readable output.
 
 ## Installation
-
 ```bash
 # From source (recommended during WIP)
 git clone https://github.com/vindicta-platform/Vindicta-CLI.git
@@ -26,7 +24,6 @@ uv pip install git+https://github.com/vindicta-platform/Vindicta-CLI.git
 ```
 
 ## Quick Start
-
 ```bash
 # Initialize a workspace with all platform repos
 vindicta dev init -w ~/vindicta-workspace
@@ -42,7 +39,6 @@ vindicta dev doctor
 ```
 
 ## Commands
-
 All commands live under the `vindicta dev` namespace.
 
 | Command                     | Description                                                                            |
@@ -62,7 +58,6 @@ All commands live under the `vindicta dev` namespace.
 > Every command supports `--json` for machine-readable output and `--verbose` / `-v` for detailed logging.
 
 ## Project Structure
-
 ```
 Vindicta-CLI/
 ├── src/vindicta_cli/
@@ -116,7 +111,6 @@ Vindicta-CLI/
 ```
 
 ## Development
-
 ```bash
 # Clone & install
 git clone https://github.com/vindicta-platform/Vindicta-CLI.git
@@ -143,7 +137,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development workflow, SDD 
 See [docs/SETUP.md](./docs/SETUP.md) for detailed setup and shell completion instructions.
 
 ## Tech Stack
-
 | Component        | Choice        | Notes                             |
 | ---------------- | ------------- | --------------------------------- |
 | CLI framework    | Typer ≥0.12   | Declarative, type-hinted CLI      |
@@ -155,6 +148,15 @@ See [docs/SETUP.md](./docs/SETUP.md) for detailed setup and shell completion ins
 | Type checker     | mypy ≥1.10    | Static type analysis              |
 | Testing          | pytest ≥8.0   | Unit, integration, contract       |
 
-## License
+## Platform Documentation
 
+> **📌 Important:** All cross-cutting decisions, feature proposals, and platform-wide architecture documentation live in [**Platform-Docs**](https://github.com/vindicta-platform/Platform-Docs).
+>
+> Any decision affecting multiple repos **must** be recorded there before implementation.
+
+- 📋 [Feature Proposals](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs/proposals)
+- 🏗️ [Architecture Decisions](https://github.com/vindicta-platform/Platform-Docs/tree/main/docs)
+- 📖 [Contributing Guide](https://github.com/vindicta-platform/Platform-Docs/blob/main/CONTRIBUTING.md)
+
+## License
 MIT License — See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary

Adds cross-references to [Platform-Docs](https://github.com/vindicta-platform/Platform-Docs) as the canonical source of truth for cross-cutting decisions, feature proposals, and platform-wide documentation.

### Changes
- **README.md**: Added `## Platform Documentation` section with links to proposals, architecture decisions, and contributing guide
- **CONTRIBUTING.md**: New file with cross-cutting decision policy requiring Platform-Docs recording before implementation

Part of the org-wide documentation standardization effort.