### PR TITLE
chore: implement aggressive pre-commit and local act CI (Phase 1)

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,24 @@
+# ==========================================================================
+# Act configuration — local GitHub Actions runner
+# ==========================================================================
+# Usage:
+#   act push                        # run push-triggered workflows
+#   act push -e .github/act/push.json  # with custom event payload
+#   act push --dryrun               # parse-only, no execution
+#   act pull_request                # run PR-triggered workflows
+# ==========================================================================
+
+# Default platform image (smaller than full GitHub runner)
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+# Reuse local containers between runs for speed
+--reuse
+
+# Bind the working directory
+--bind
+
+# Use .env file for secrets (create .secrets for act if needed)
+--secret-file .secrets
+
+# Default event file
+--eventpath .github/act/push.json

--- a/.github/act/pull_request.json
+++ b/.github/act/pull_request.json
@@ -1,0 +1,26 @@
+{
+    "action": "opened",
+    "number": 1,
+    "pull_request": {
+        "number": 1,
+        "title": "Test PR",
+        "head": {
+            "ref": "feat/pre-commit-rollout",
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        },
+        "base": {
+            "ref": "main",
+            "sha": "cafebabecafebabecafebabecafebabecafebabe"
+        }
+    },
+    "repository": {
+        "full_name": "vindicta-platform/Vindicta-CLI",
+        "default_branch": "main",
+        "owner": {
+            "login": "vindicta-platform"
+        }
+    },
+    "sender": {
+        "login": "developer"
+    }
+}

--- a/.github/act/push.json
+++ b/.github/act/push.json
@@ -1,0 +1,19 @@
+{
+  "ref": "refs/heads/feat/pre-commit-rollout",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "repository": {
+    "full_name": "vindicta-platform/Vindicta-CLI",
+    "default_branch": "main",
+    "owner": {
+      "login": "vindicta-platform"
+    }
+  },
+  "pusher": {
+    "name": "developer",
+    "email": "dev@vindicta.dev"
+  },
+  "sender": {
+    "login": "developer"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,153 @@
+# ==========================================================================
+# Vindicta Platform — Local-Testable CI Workflow
+# ==========================================================================
+# This workflow is designed to be run both on GitHub Actions AND locally
+# via act:
+#   act push -e .github/act/push.json
+#   act pull_request -e .github/act/pull_request.json
+# ==========================================================================
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.specify/**'
+      - 'LICENSE'
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: Pre-Commit Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for pre-commit config
+        id: check-config
+        run: |
+          if [ -f .pre-commit-config.yaml ]; then
+            echo "has_config=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_config=false" >> $GITHUB_OUTPUT
+            echo "::notice::No .pre-commit-config.yaml found, skipping"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.check-config.outputs.has_config == 'true'
+        with:
+          python-version: '3.12'
+
+      - uses: pre-commit/action@v3.0.1
+        if: steps.check-config.outputs.has_config == 'true'
+        with:
+          extra_args: --all-files --show-diff-on-failure
+
+  test:
+    name: Python Tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Python source files
+        id: check-python
+        run: |
+          if [ -d "src" ] || find . -name "*.py" -not -path "./.git/*" | head -1 | grep -q .; then
+            echo "has_python=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_python=false" >> $GITHUB_OUTPUT
+            echo "::notice::No Python source files found, skipping tests"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.check-python.outputs.has_python == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@v4
+        if: steps.check-python.outputs.has_python == 'true'
+
+      - name: Cache uv dependencies
+        if: steps.check-python.outputs.has_python == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        if: steps.check-python.outputs.has_python == 'true'
+        run: uv sync --dev
+
+      - name: Lint with ruff
+        if: steps.check-python.outputs.has_python == 'true'
+        run: uv run ruff check src/ --output-format=github
+
+      - name: Type check with mypy
+        if: steps.check-python.outputs.has_python == 'true'
+        run: uv run mypy src/ --ignore-missing-imports
+
+      - name: Check for tests directory
+        if: steps.check-python.outputs.has_python == 'true'
+        id: check-tests
+        run: |
+          if [ -d "tests" ] && find tests -name "*.py" | head -1 | grep -q .; then
+            echo "has_tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_tests=false" >> $GITHUB_OUTPUT
+            echo "::notice::No tests found, skipping test execution"
+          fi
+
+      - name: Run tests with coverage
+        if: steps.check-python.outputs.has_python == 'true' && steps.check-tests.outputs.has_tests == 'true'
+        run: uv run pytest tests/ -v --tb=short --cov=src --cov-report=xml
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: matrix.python-version == '3.12' && steps.check-tests.outputs.has_tests == 'true'
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  convert-to-draft:
+    name: Convert to Draft on Failure
+    runs-on: ubuntu-latest
+    needs: [pre-commit, test]
+    if: failure() && github.event_name == 'pull_request'
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Convert PR to Draft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mutation = `mutation($id: ID!) {
+              convertPullRequestToDraft(input: {pullRequestId: $id}) {
+                pullRequest { isDraft }
+              }
+            }`;
+            try {
+              await github.graphql(mutation, {
+                id: context.payload.pull_request.node_id
+              });
+              core.notice('PR converted to draft due to CI failure');
+            } catch (error) {
+              core.warning(`Could not convert to draft: ${error.message}`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: astral-sh/setup-uv@v4
+        if: steps.check-config.outputs.has_config == 'true'
+
+      - name: Install pre-commit dependencies (for local hooks)
+        if: steps.check-config.outputs.has_config == 'true'
+        run: uv sync --dev
+
       - uses: pre-commit/action@v3.0.1
         if: steps.check-config.outputs.has_config == 'true'
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .vindicta/
 *.log
 .ruff_cache/
+.secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,16 @@ repos:
   # ── Local hooks ──────────────────────────────────────────────────────
   - repo: local
     hooks:
+      # WIP Check (runs on commit)
+      - id: pytest-wip
+        name: "detect WIP tests"
+        entry: uv run python scripts/check_wip_tests.py
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        always_run: true
+        verbose: true
+
       # Push-stage: full test suite must pass before push
       - id: pytest-full
         name: "run full test suite"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,13 @@
-# Vindicta-CLI Pre-Commit Configuration
-# - On commit: formatting, linting, file hygiene, WIP test detection
-# - On push:   full pytest suite (unit + integration + contract)
+# ============================================================================
+# Vindicta Platform — Python-Aggressive Pre-Commit Config (Phase 1: Lockdown)
+# ============================================================================
+# All hooks fire on EVERY commit. This is deliberately strict.
+# See ROLLOUT.md for the phased plan to loosen over time.
+#
+# Escape hatch: SKIP=hook-id git commit -m "..."
+# ============================================================================
 
 repos:
-  # ── Ruff: lint + format ──────────────────────────────────────────────
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.7
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
-
   # ── File hygiene & safety ────────────────────────────────────────────
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -18,25 +15,64 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-      - id: check-toml
+        args: [--unsafe]
       - id: check-json
+      - id: check-toml
       - id: check-merge-conflict
-      - id: debug-statements
+      - id: check-added-large-files
+        args: [--maxkb=500]
       - id: detect-private-key
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: debug-statements
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-symlinks
+      - id: check-executables-have-shebangs
+
+  # ── Python: Ruff lint + format ───────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.7
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # ── Secret scanning ─────────────────────────────────────────────────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
+    hooks:
+      - id: gitleaks
+
+  # ── GitHub Actions linting ───────────────────────────────────────────
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
+  # ── Shell script linting ─────────────────────────────────────────────
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  # ── Markdown linting ─────────────────────────────────────────────────
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.1
+    hooks:
+      - id: markdownlint-cli2
+        args: [--fix]
+
+  # ── Conventional Commits (commit-msg stage) ──────────────────────────
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.4.1
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
 
   # ── Local hooks ──────────────────────────────────────────────────────
   - repo: local
     hooks:
-      # Commit-stage: catch WIP-marked tests before they land
-      - id: pytest-wip
-        name: "detect WIP tests"
-        entry: uv run python scripts/check_wip_tests.py
-        language: system
-        pass_filenames: false
-        stages: [pre-commit]
-        always_run: true
-        verbose: true
-
       # Push-stage: full test suite must pass before push
       - id: pytest-full
         name: "run full test suite"

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,0 +1,5 @@
+# Act local secrets file
+# Copy this to .secrets and fill in values
+# NEVER commit this file — it's in .gitignore
+#
+# GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.7",
     "pyadr>=0.19",
+    "commitizen>=4.4",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -47,3 +48,10 @@ asyncio_mode = "auto"
 markers = [
     "wip: marks tests as work-in-progress (deselected by default, caught by pre-commit)",
 ]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_scheme = "semver"
+version_provider = "pep621"
+update_map_description = true


### PR DESCRIPTION
## Pre-commit & Act Rollout: Phase 1 (Aggressive Lockdown)

This PR implements the first stage of the organization-wide pre-commit and local CI testing rollout for **Vindicta-CLI**.

### Changes
- **Aggressive Pre-commit Config**: 19 hooks enforcing file hygiene, secret scanning, formatting (Ruff), linting, and conventional commits on every commit.
- **Local CI Testing (`act`)**: Added `.actrc` and event fixtures (`.github/act/`) to allow developers to run the CI suite locally in Docker before pushing.
- **Unified CI Workflow**: Added `.github/workflows/ci.yml` which mirrors the org-wide Python template but is optimized for both GitHub Actions and local `act` runs.
- **Safety**: Updated `.gitignore` to block `.secrets` (used by `act`).

### How to test locally
1. `pre-commit install`
2. `act push` (requires Docker)

This is part of the **Tier 1 (Python)** rollout. Pending approval, I will proceed with the next repository in this tier.
